### PR TITLE
Check from local ruleset feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-src/spito
+spito
 *.exe
 *.exe~
 *.dll

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -10,6 +10,7 @@ import (
 	"github.com/godbus/dbus"
 	"github.com/spf13/cobra"
 	"os"
+	"path/filepath"
 )
 
 var checkFileCmd = &cobra.Command{
@@ -36,15 +37,27 @@ var checkFileCmd = &cobra.Command{
 }
 
 var checkCmd = &cobra.Command{
-	Use:   "check {ruleset identifier} {rule}",
+	Use:   "check {ruleset identifier or path} {rule}",
 	Short: "Check whether your machine pass rule",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		runtimeData := getInitialRuntimeData(cmd)
-		identifier := args[0]
+		identifierOrPath := args[0]
 		ruleName := args[1]
 
-		doesRulePass, err := checker.CheckRuleByIdentifier(&runtimeData, identifier, ruleName)
+		if executionPath, err := os.Getwd(); err == nil {
+			localRulesetPath := identifierOrPath
+			if filepath.IsLocal(identifierOrPath) {
+				localRulesetPath = filepath.Join(executionPath, identifierOrPath)
+			}
+
+			pathExists, err := shared.DoesPathExists(localRulesetPath)
+			if err == nil && pathExists {
+				identifierOrPath = localRulesetPath
+			}
+		}
+
+		doesRulePass, err := checker.CheckRuleByIdentifier(&runtimeData, identifierOrPath, ruleName)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -51,7 +51,7 @@ var checkCmd = &cobra.Command{
 				localRulesetPath = filepath.Join(executionPath, identifierOrPath)
 			}
 
-			pathExists, err := shared.DoesPathExists(localRulesetPath)
+			pathExists, err := shared.DoesPathExist(localRulesetPath)
 			if err == nil && pathExists {
 				identifierOrPath = localRulesetPath
 			}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,18 +25,15 @@ func handleGenerate(cmd *cobra.Command, args []string) {
 		printErrorAndExit(errors.New("the rule path cannot be empty"))
 	}
 
-	configFileContents, err := os.ReadFile(checker.CONFIG_FILENAME)
+	configFileContents, err := os.ReadFile(checker.ConfigFilename)
 	if os.IsNotExist(err) {
-		printErrorAndExit(errors.New("please run this commnd inside an actual spito ruleset directory"))
+		printErrorAndExit(errors.New("please run this command inside an actual spito ruleset directory"))
 	}
 	handleError(err)
 
 	config := ConfigFileLayout{}
 	err = yaml.Unmarshal(configFileContents, &config)
 	handleError(err)
-
-	rulesetLocation := checker.RuleSetLocation{}
-	rulesetLocation.New(config.Identifier)
 
 	err = os.Mkdir(rulesDirectory, 0700)
 	if err != nil && !os.IsExist(err) {
@@ -57,7 +54,7 @@ func handleGenerate(cmd *cobra.Command, args []string) {
 
 	config.Rules[rulePathTokens[len(rulePathTokens)-1]] = "./rules/" + rulePath + ".lua"
 
-	configFile, err := os.Create(checker.CONFIG_FILENAME)
+	configFile, err := os.Create(checker.ConfigFilename)
 	defer configFile.Close()
 	handleError(err)
 	configFileContents, err = yaml.Marshal(config)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -51,17 +51,16 @@ var newRulesetCommand = &cobra.Command{
 		shouldAssumeDefaultValues, err := cmd.Flags().GetBool("non-interactive")
 		handleError(err)
 
-		newRulesetLocation := checker.RuleSetLocation{}
 		gitUsername := getGitUsername()
 		rulesetIdentifier := gitUsername + "/" + rulesetName
-		newRulesetLocation.New(rulesetIdentifier)
+		newRulesetLocation := checker.NewRulesetLocation(rulesetIdentifier)
 
-		repositoryUrl := newRulesetLocation.GetFullUrl()
+		// Because we create RulesetLocation based on git identifier, we can be sure that full url is not nil
+		repositoryUrl := *newRulesetLocation.GetFullUrl()
 		rulesetRepositoryName := rulesetName
 		hostingProvider := checker.GetDefaultRepoPrefix()
 
 		if !shouldAssumeDefaultValues {
-
 			var input string
 
 			fmt.Printf("Enter your git service username (%s): ", gitUsername)
@@ -110,14 +109,14 @@ var newRulesetCommand = &cobra.Command{
 		_, err = git.PlainInit(rulesetName, false)
 		handleError(err)
 
-		filesToBeCreated := []string{"README.md", checker.LOCK_FILENAME}
+		filesToBeCreated := []string{"README.md", checker.LockFilename}
 		for _, fileName := range filesToBeCreated {
 			file, err := os.Create(rulesetName + "/" + fileName)
 			handleError(err)
 			file.Close()
 		}
 
-		configFile, err := os.Create(rulesetName + "/" + checker.CONFIG_FILENAME)
+		configFile, err := os.Create(rulesetName + "/" + checker.ConfigFilename)
 		handleError(err)
 		config := ConfigFileLayout{
 			Repo_url:   repositoryUrl,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/avorty/spito/cmd/cmdApi"
 	"github.com/spf13/cobra"
 	"os"
@@ -30,14 +29,16 @@ var rootCmd = &cobra.Command{
 	Use:   "spito",
 	Short: "spito is powerful config management system",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Try running subcommand instead")
+		err := cmd.Help()
+		if err != nil {
+			printErrorAndExit(err)
+		}
 	},
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		printErrorAndExit(err)
 	}
 }
 

--- a/internal/checker/check.go
+++ b/internal/checker/check.go
@@ -116,7 +116,6 @@ func _internalCheckRule(importLoopData *shared.ImportLoopData, identifierOrPath 
 			errChan <- errors.New("Failed to fetch rules from: " + identifier + "\n" + err.Error())
 			panic(nil)
 		}
-
 	}
 
 	lockfilePath := rulesetLocation.GetRulesetPath() + "/" + LockFilename

--- a/internal/checker/check.go
+++ b/internal/checker/check.go
@@ -110,7 +110,7 @@ func _internalCheckRule(importLoopData *shared.ImportLoopData, identifierOrPath 
 	}
 	rulesHistory.Push(identifier, name, true)
 
-	if !rulesetLocation.IsLocal() {
+	if !rulesetLocation.IsPath {
 		err := FetchRuleset(&rulesetLocation)
 		if err != nil {
 			errChan <- errors.New("Failed to fetch rules from: " + identifier + "\n" + err.Error())

--- a/internal/checker/resolve_script.go
+++ b/internal/checker/resolve_script.go
@@ -134,7 +134,6 @@ func FetchRuleset(rulesetLocation *RulesetLocation) error {
 	})
 
 	if errors.Is(err, git.ErrRepositoryAlreadyExists) {
-		println(err)
 		return nil
 	}
 	return err

--- a/internal/checker/resolve_script.go
+++ b/internal/checker/resolve_script.go
@@ -130,7 +130,7 @@ func FetchRuleset(rulesetLocation *RulesetLocation) error {
 	}
 
 	_, err = git.PlainClone(rulesetLocation.GetRulesetPath(), false, &git.CloneOptions{
-		URL: "https://" + *rulesetLocation.simpleUrl,
+		URL: *rulesetLocation.GetFullUrl(),
 	})
 
 	if errors.Is(err, git.ErrRepositoryAlreadyExists) {

--- a/internal/checker/resolve_script.go
+++ b/internal/checker/resolve_script.go
@@ -45,8 +45,6 @@ func getRulePath(rulesetPath, ruleName string) (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("%+v\n", spitoRulesYaml.Rules)
-
 	for key := range spitoRulesYaml.Rules {
 		if key != ruleName {
 			continue

--- a/internal/checker/resolve_script.go
+++ b/internal/checker/resolve_script.go
@@ -27,12 +27,12 @@ func (s SpitoRulesYaml) getRulesStructVal(key string) (RuleConf, bool) {
 	return val, ok
 }
 
-func getRulePath(ruleSetLocation RuleSetLocation, ruleName string) (string, error) {
+func getRulePath(rulesetPath, ruleName string) (string, error) {
 	// Support for both .yaml and .yml
-	spitoRulesDataBytes, err := os.ReadFile(ruleSetLocation.GetRuleSetPath() + "/spito-rules.yaml")
+	spitoRulesDataBytes, err := os.ReadFile(rulesetPath + "/spito-rules.yaml")
 	if errors.Is(err, fs.ErrNotExist) {
 		var _err error
-		spitoRulesDataBytes, _err = os.ReadFile(ruleSetLocation.GetRuleSetPath() + "/spito-rules.yml")
+		spitoRulesDataBytes, _err = os.ReadFile(rulesetPath + "/spito-rules.yml")
 		if _err != nil {
 			return "", _err
 		}
@@ -66,7 +66,7 @@ func getRulePath(ruleSetLocation RuleSetLocation, ruleName string) (string, erro
 		} else if path[0] != '/' {
 			path = "/" + path
 		}
-		path = ruleSetLocation.GetRuleSetPath() + path
+		path = rulesetPath + path
 
 		return path, nil
 	}
@@ -74,8 +74,8 @@ func getRulePath(ruleSetLocation RuleSetLocation, ruleName string) (string, erro
 	return "", fmt.Errorf("NOT FOUND rule called: " + ruleName)
 }
 
-func getScript(ruleSetLocation RuleSetLocation, ruleName string) (string, error) {
-	scriptPath, err := getRulePath(ruleSetLocation, ruleName)
+func getScript(rulesetPath, ruleName string) (string, error) {
+	scriptPath, err := getRulePath(rulesetPath, ruleName)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +98,7 @@ func GetAllDownloadedRuleSets() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ruleSets []string
+	var rulesets []string
 
 	for _, provider := range providerDirs {
 		providerName := provider.Name()
@@ -114,25 +114,25 @@ func GetAllDownloadedRuleSets() ([]string, error) {
 			}
 			for _, ruleSet := range userDirs {
 				ruleSetName := ruleSet.Name()
-				ruleSets = append(ruleSets,
+				rulesets = append(rulesets,
 					fmt.Sprintf("%s/%s/%s", providerName, userName, ruleSetName),
 				)
 			}
 		}
 	}
 
-	return ruleSets, nil
+	return rulesets, nil
 }
 
-func FetchRuleSet(ruleSetLocation *RuleSetLocation) error {
-	err := ruleSetLocation.CreateDir()
+func FetchRuleset(rulesetLocation *RulesetLocation) error {
+	err := rulesetLocation.CreateDir()
 	if err != nil {
 		println(err.Error())
 		return err
 	}
 
-	_, err = git.PlainClone(ruleSetLocation.GetRuleSetPath(), false, &git.CloneOptions{
-		URL: ruleSetLocation.GetFullUrl(),
+	_, err = git.PlainClone(rulesetLocation.GetRulesetPath(), false, &git.CloneOptions{
+		URL: "https://" + *rulesetLocation.simpleUrl,
 	})
 
 	if errors.Is(err, git.ErrRepositoryAlreadyExists) {

--- a/internal/checker/resolve_script_test.go
+++ b/internal/checker/resolve_script_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestFetchRuleSet(t *testing.T) {
-	ruleSetLocation := RuleSetLocation{}
-	ruleSetLocation.New("https://github.com/avorty/spito-ruleset/")
+	ruleSetLocation := NewRulesetLocation("https://github.com/avorty/spito-ruleset/")
 
 	err := ruleSetLocation.CreateDir()
 	if err != nil {
@@ -21,23 +20,23 @@ func TestFetchRuleSet(t *testing.T) {
 	}
 
 	isRuleSetAlreadyDownloaded := slices.ContainsFunc(sets, func(s string) bool {
-		return strings.Contains(s, ruleSetLocation.simpleUrl)
+		return strings.Contains(s, ruleSetLocation.GetIdentifier())
 	})
 
 	if isRuleSetAlreadyDownloaded {
 		t.Log("!!! TEST SKIPPED !!!")
 		t.Log("Test uses ruleset which you downloaded before running this test")
-		t.Log("Delete ruleset called " + ruleSetLocation.simpleUrl + " if you want to run this test")
+		t.Log("Delete ruleset called " + ruleSetLocation.GetIdentifier() + " if you want to run this test")
 
 		t.SkipNow()
 	}
 
-	err = FetchRuleSet(&ruleSetLocation)
+	err = FetchRuleset(&ruleSetLocation)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = os.RemoveAll(ruleSetLocation.GetRuleSetPath())
+	err = os.RemoveAll(ruleSetLocation.GetRulesetPath())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/shared/path.go
+++ b/pkg/shared/path.go
@@ -1,0 +1,16 @@
+package shared
+
+import (
+	"os"
+)
+
+func DoesPathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}

--- a/pkg/shared/path.go
+++ b/pkg/shared/path.go
@@ -4,7 +4,7 @@ import (
 	"os"
 )
 
-func DoesPathExists(path string) (bool, error) {
+func DoesPathExist(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
 		return true, nil


### PR DESCRIPTION
Previously the only way to check rule without specifying exact script path was e.g.: `spito check Avorty/spito-ruleset dbus`
Now it is also possible to check from local rulesets like this: `spito check /home/bstrama/work_dir/spito-ruleset dbus` or `spito check ~/work_dir/spito-ruleset dbus `